### PR TITLE
Implemented default exchange functionality.

### DIFF
--- a/RabbitMQ.Fakes.DotNetCore.Tests/FakeModelTests.cs
+++ b/RabbitMQ.Fakes.DotNetCore.Tests/FakeModelTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using FluentAssertions;
+using NUnit.Framework;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Fakes.DotNetStandard;
@@ -79,9 +80,9 @@ namespace RabbitMQ.Fakes.DotNetCore.Tests
             model.ExchangeDeclare(exchange: exchangeName, type: exchangeType, durable: isDurable, autoDelete: isAutoDelete, arguments: arguments);
 
             // Assert
-            Assert.That(node.Exchanges, Has.Count.EqualTo(1));
+            node.Exchanges.Should().ContainKey(exchangeName, "an exchange was declared with name {0}", exchangeName);
 
-            var exchange = node.Exchanges.First();
+            var exchange = node.Exchanges[exchangeName];
             AssertExchangeDetails(exchange, exchangeName, isAutoDelete, arguments, isDurable, exchangeType);
         }
 
@@ -100,9 +101,9 @@ namespace RabbitMQ.Fakes.DotNetCore.Tests
             model.ExchangeDeclare(exchange: exchangeName, type: exchangeType, durable: isDurable);
 
             // Assert
-            Assert.That(node.Exchanges, Has.Count.EqualTo(1));
+            node.Exchanges.Should().ContainKey(exchangeName, "an exchange was declared with name {0}", exchangeName);
 
-            var exchange = node.Exchanges.First();
+            var exchange = node.Exchanges[exchangeName];
             AssertExchangeDetails(exchange, exchangeName, false, null, isDurable, exchangeType);
         }
 
@@ -120,9 +121,9 @@ namespace RabbitMQ.Fakes.DotNetCore.Tests
             model.ExchangeDeclare(exchange: exchangeName, type: exchangeType);
 
             // Assert
-            Assert.That(node.Exchanges, Has.Count.EqualTo(1));
+            node.Exchanges.Should().ContainKey(exchangeName, "an exchange was declared with name {0}", exchangeName);
 
-            var exchange = node.Exchanges.First();
+            var exchange = node.Exchanges[exchangeName];
             AssertExchangeDetails(exchange, exchangeName, false, null, false, exchangeType);
         }
 
@@ -139,9 +140,9 @@ namespace RabbitMQ.Fakes.DotNetCore.Tests
             model.ExchangeDeclarePassive(exchange: exchangeName);
 
             // Assert
-            Assert.That(node.Exchanges, Has.Count.EqualTo(1));
+            node.Exchanges.Should().ContainKey(exchangeName, "an exchange was declared with name {0}", exchangeName);
 
-            var exchange = node.Exchanges.First();
+            var exchange = node.Exchanges[exchangeName];
             AssertExchangeDetails(exchange, exchangeName, false, null, false, null);
         }
 
@@ -162,20 +163,19 @@ namespace RabbitMQ.Fakes.DotNetCore.Tests
             model.ExchangeDeclareNoWait(exchange: exchangeName, type: exchangeType, durable: isDurable, autoDelete: isAutoDelete, arguments: arguments);
 
             // Assert
-            Assert.That(node.Exchanges, Has.Count.EqualTo(1));
+            node.Exchanges.Should().ContainKey(exchangeName, "an exchange was declared with name {0}", exchangeName);
 
-            var exchange = node.Exchanges.First();
+            var exchange = node.Exchanges[exchangeName];
             AssertExchangeDetails(exchange, exchangeName, isAutoDelete, arguments, isDurable, exchangeType);
         }
 
-        private static void AssertExchangeDetails(KeyValuePair<string, Exchange> exchange, string exchangeName, bool isAutoDelete, IDictionary<string, object> arguments, bool isDurable, string exchangeType)
+        private static void AssertExchangeDetails(Exchange exchange, string exchangeName, bool isAutoDelete, IDictionary<string, object> arguments, bool isDurable, string exchangeType)
         {
-            Assert.That(exchange.Key, Is.EqualTo(exchangeName));
-            Assert.That(exchange.Value.AutoDelete, Is.EqualTo(isAutoDelete));
-            Assert.That(exchange.Value.Arguments, Is.EqualTo(arguments));
-            Assert.That(exchange.Value.IsDurable, Is.EqualTo(isDurable));
-            Assert.That(exchange.Value.Name, Is.EqualTo(exchangeName));
-            Assert.That(exchange.Value.Type, Is.EqualTo(exchangeType));
+            Assert.That(exchange.AutoDelete, Is.EqualTo(isAutoDelete));
+            Assert.That(exchange.Arguments, Is.EqualTo(arguments));
+            Assert.That(exchange.IsDurable, Is.EqualTo(isDurable));
+            Assert.That(exchange.Name, Is.EqualTo(exchangeName));
+            Assert.That(exchange.Type, Is.EqualTo(exchangeType));
         }
 
         [Test]
@@ -192,7 +192,7 @@ namespace RabbitMQ.Fakes.DotNetCore.Tests
             model.ExchangeDelete(exchange: exchangeName);
 
             // Assert
-            Assert.That(node.Exchanges, Has.Count.EqualTo(0));
+            node.Exchanges.Should().NotContainKey(exchangeName, "the exchange with name {0} was deleted", exchangeName);
         }
 
         [Test]
@@ -211,7 +211,7 @@ namespace RabbitMQ.Fakes.DotNetCore.Tests
             model.ExchangeDelete(exchange: exchangeName, ifUnused: ifUnused);
 
             // Assert
-            Assert.That(node.Exchanges, Has.Count.EqualTo(0));
+            node.Exchanges.Should().NotContainKey(exchangeName, "the exchange with name {0} was deleted", exchangeName);
         }
 
         [Test]
@@ -230,7 +230,7 @@ namespace RabbitMQ.Fakes.DotNetCore.Tests
             model.ExchangeDeleteNoWait(exchange: exchangeName, ifUnused: ifUnused);
 
             // Assert
-            Assert.That(node.Exchanges, Has.Count.EqualTo(0));
+            node.Exchanges.Should().NotContainKey(exchangeName, "the exchange with name {0} was deleted", exchangeName);
         }
 
         [Test]
@@ -247,7 +247,7 @@ namespace RabbitMQ.Fakes.DotNetCore.Tests
             model.ExchangeDelete(exchange: "someOtherExchange");
 
             // Assert
-            Assert.That(node.Exchanges, Has.Count.EqualTo(1));
+            node.Exchanges.Should().NotContainKey("someOtherExchange", "the exchange with name {0} never existed", "someOtherExchange");
         }
 
         [Test]
@@ -399,6 +399,8 @@ namespace RabbitMQ.Fakes.DotNetCore.Tests
 
             // Assert
             Assert.That(node.Queues, Has.Count.EqualTo(1));
+
+            node.DefaultExchange.Bindings.Should().ContainKey(queueName, "all newly declared queues are implicitly bound to the default exchange");
 
             var queue = node.Queues.First();
             AssertQueueDetails(queue, queueName, isAutoDelete, arguments, isDurable, isExclusive);

--- a/RabbitMQ.Fakes.DotNetStandard/FakeModel.cs
+++ b/RabbitMQ.Fakes.DotNetStandard/FakeModel.cs
@@ -416,6 +416,14 @@ namespace RabbitMQ.Fakes.DotNetStandard
             Func<string, Queue, Queue> updateFunction = (name, existing) => existing;
             _server.Queues.AddOrUpdate(queue, queueInstance, updateFunction);
 
+            var exchangeBinding = new ExchangeQueueBinding
+            {
+                RoutingKey = queueInstance.Name,
+                Exchange = _server.DefaultExchange,
+                Queue = queueInstance
+            };
+            _server.DefaultExchange.Bindings.AddOrUpdate(exchangeBinding.RoutingKey, exchangeBinding, (routingKey, existing) => existing);
+
             return new QueueDeclareOk(queue, 0, 0);
         }
 

--- a/RabbitMQ.Fakes.DotNetStandard/RabbitServer.cs
+++ b/RabbitMQ.Fakes.DotNetStandard/RabbitServer.cs
@@ -5,13 +5,37 @@ namespace RabbitMQ.Fakes.DotNetStandard
 {
     public class RabbitServer
     {
-        public ConcurrentDictionary<string, Exchange> Exchanges = new ConcurrentDictionary<string, Exchange>();
-        public ConcurrentDictionary<string, Queue> Queues = new ConcurrentDictionary<string, Queue>();
+        public ConcurrentDictionary<string, Exchange> Exchanges { get; }
+
+        public ConcurrentDictionary<string, Queue> Queues { get; }
+
+        public Exchange DefaultExchange => Exchanges[string.Empty];
+
+        public RabbitServer()
+        {
+            Exchanges = new ConcurrentDictionary<string, Exchange>();
+            Queues = new ConcurrentDictionary<string, Queue>();
+
+            InitializeDefaultExchange();
+        }
 
         public void Reset()
         {
             Exchanges.Clear();
             Queues.Clear();
+
+            // Need to re-initialize the default exchange.
+            InitializeDefaultExchange();
+        }
+
+        private void InitializeDefaultExchange()
+        {
+            // https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default
+            Exchanges[string.Empty] = new Exchange
+            {
+                Name = string.Empty,
+                Type = "Direct"
+            };
         }
     }
 }


### PR DESCRIPTION
Closes #3.

Default exchange is created upon `RabbitServer` construction, and any queues declared are automatically bound to the default exchange.